### PR TITLE
Update de_DE.lang

### DIFF
--- a/src/main/resources/assets/pcl_lc/lang/de_DE.lang
+++ b/src/main/resources/assets/pcl_lc/lang/de_DE.lang
@@ -7,7 +7,7 @@ item.controllerCrystal.name=Stargate Kontrollkristall
 item.energyCrystal.name=Energiekristall
 
 tile.blockLiquidNaquadah.name=Flüssiges Naquadah
-item.liquidNaquadahBucket.name=Eimer mit flüssiges Naquadah
+item.liquidNaquadahBucket.name=Eimer mit flüssigem Naquadah
 
 tile.lanteaDecor.1.name=Verzierter Antiker Stahl
 tile.lanteaDecor.2.name=Antiker Stahl
@@ -17,18 +17,18 @@ tile.lanteaGlassDecor.1.name=Antiker-Glas
 
 tile.lanteaDecor.3.name=Verziertes Goa'uld Gold
 tile.lanteaDecor.4.name=Goa'uld Gold
-tile.goauldPatternedGoldDecorStair.name=Goauld Goldtreppe
-tile.goauldGoldDecorStair.name=Verzierte Goauld Goldtreppe
+tile.goauldPatternedGoldDecorStair.name=Goa'uld Goldtreppe
+tile.goauldGoldDecorStair.name=Verzierte Goa'uld Goldtreppe
 
 tile.lanteaOre.0.name=Naquadah Erz
 item.lanteaOre.0.name=Naquadah
 item.lanteaOreIngot.0.name=Naquadah Barren
 tile.lanteaOreIngotBlock.0.name=Naquadah Block
 
-tile.lanteaOre.1.name=Naqahdriah Erz
-item.lanteaOre.1.name=Naqahdriah
-item.lanteaOreIngot.1.name=Naqahdriah Barren
-tile.lanteaOreIngotBlock.1.name=Naqahdriah Block
+tile.lanteaOre.1.name=Naquahdriah Erz
+item.lanteaOre.1.name=Naquahdriah
+item.lanteaOreIngot.1.name=Naquahdriah Barren
+tile.lanteaOreIngotBlock.1.name=Naquahdriah Block
 
 tile.lanteaOre.2.name=Trinium Erz
 item.lanteaOre.2.name=Trinium
@@ -37,6 +37,7 @@ tile.lanteaOreIngotBlock.2.name=Trinium Block
 
 tile.naquadahGenerator.name=Naquadah Generator
 tile.ringPlatform.name=Ring Transporter
+item.transportRingActivator.name=Handgerät
 
 item.tokraSpawnEgg.name=Erschaffe Tok'ra
 item.lanteadebug.name=LanteaCraft Debugger


### PR DESCRIPTION
Fix some mistakes. Added Item for Ring Transporter. In german the item has multi use:
- Generate a burst of energy that flings a person across the room and injures or kills
- Person torture, will-make, stun or kill by irradiation of the brain
- Create protective shield that protects against Spears, zats and the Tau'ri weapons. 
- Transmit thoughts
- Activate the ring transporter and the Asgard beam technology
- Seth is also used to make Nish'ta flow out of its containers
- Osiris used it to enable her escape spaceship on a computer in her temple
- Thoth activated with his hand module is a device that apparently scans the Super Soldiers
- Ba'al thus activated his hologram device
- Absorb bursts of fire from a Zat'n'ktel
